### PR TITLE
Stop using sys.setdefaultencoding

### DIFF
--- a/cvrf_util.py
+++ b/cvrf_util.py
@@ -311,12 +311,9 @@ def cvrf_dump(results, strip_ns, output_format, cvrf_doc, cvrf_version, args, re
     """
     for key in results:
         if key == output_format:       # if no file name specified, use stdout - "stdout"
-            f = codecs.EncodedFile(sys.stdout, data_encoding="utf-8")   # "UTF-8"
+            f = sys.stdout
         else:
-            try:
-                f = codecs.open(key, "w", encoding="utf-8")   # "UTF-8"
-            except IOError as e:
-                sys.exit("{0}: I/O error({1}) \"{2}\": {3}".format(progname, e.errno, key, e.strerror))
+            f = open(key, "w")
 
         print_header_rows(cvrf_doc, cvrf_version, args, output_format, f, related_product_tags)
 
@@ -642,9 +639,6 @@ def get_first_node_in_doc(parsables, cvrf_doc):
 
 
 def main(progname=None):
-
-    reload(sys)
-    sys.setdefaultencoding('utf8')
 
     # simple standard python logging
     logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', filename='csaf-parser.log', level=logging.DEBUG)  # filemode='w',


### PR DESCRIPTION
Simplify how we open files (or sys.stdout) for output. Stop using the open() functions from the codecs module, and use the regular built-in open() instead.

Resolves #2 