### PR TITLE
Fixed version check to work with a default namespace

### DIFF
--- a/cvrf_util.py
+++ b/cvrf_util.py
@@ -775,7 +775,13 @@ def main(progname=None):
     # check to make sure cvrf namespace in doc matches cvrf version from command line args
     logging.info('verifying cvrf version...')
     first_node = get_first_node_in_doc(parsables, cvrf_doc)
-    doc_cvrf_version = first_node.nsmap['cvrf'] if first_node is not None else ''
+    if first_node is not None:
+        if 'cvrf' in first_node.nsmap:
+            doc_cvrf_version = first_node.nsmap['cvrf']
+        else:
+            doc_cvrf_version = first_node.nsmap[None]
+    else:
+        doc_cvrf_version = ''
     logging.info('cvrf version from document: ' + doc_cvrf_version)
     arg_cvrf_version = CVRF_Syntax(cvrf_version).NAMESPACES["CVRF"].replace("{", "").replace("}", "")
     logging.info('cvrf version from args: ' + arg_cvrf_version)


### PR DESCRIPTION
Hello. The examples include and the parser expects a `cvrf` namespace, however then the default namespace is used so the `cvrf` prefix is unused. Some XML tools have troubles generating a namespace that is never used. The following CVRF is (in my opinion) a perfectly valid document, but the parser refuses it as it is missing the (unused) `cvrf` namespace.
```xml
<?xml version="1.0"encoding="UTF-8"?>
<cvrfdoc xmlns="http://www.icasi.org/CVRF/schema/cvrf/1.1">
<DocumentTitle>blabla</DocumentTitle>
...
```
I suggest to enhance the parser a bit, so it accepts documents like the above.